### PR TITLE
[docker-selinux] Docker selinux interface file will be shipped with selinux-policy rpm package

### DIFF
--- a/docker.spec
+++ b/docker.spec
@@ -74,7 +74,7 @@
 
 # Version of SELinux we were using
 %if 0%{?fedora} >= 22
-%global selinux_policyver 3.13.1-119
+%global selinux_policyver 3.13.1-155
 %else
 %global selinux_policyver 3.13.1-39
 %endif

--- a/docker.spec
+++ b/docker.spec
@@ -452,11 +452,12 @@ install -p -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/%{repo}
 install -p -m 644 %{SOURCE6} %{buildroot}%{_sysconfdir}/sysconfig/%{repo}-network
 install -p -m 644 %{SOURCE3} %{buildroot}%{_sysconfdir}/sysconfig/%{repo}-storage
 
-%if 0%{?with_selinux}
+# We ship docker selinux interface file in selinux distro policy
+#%if 0%{?with_selinux}
 # install SELinux interfaces
-%_format INTERFACES $x.if
-install -d %{buildroot}%{_datadir}/selinux/devel/include/%{moduletype}
-install -p -m 644 %{repo}-selinux-%{ds_commit}/$INTERFACES %{buildroot}%{_datadir}/selinux/devel/include/%{moduletype}
+#%_format INTERFACES $x.if
+#install -d %{buildroot}%{_datadir}/selinux/devel/include/%{moduletype}
+#install -p -m 644 %{repo}-selinux-%{ds_commit}/$INTERFACES %{buildroot}%{_datadir}/selinux/devel/include/%{moduletype}
 
 # install policy modules
 %_format MODULES $x.pp.bz2


### PR DESCRIPTION
With this change we need to remove installing selinux interfaces during docker installation process.
